### PR TITLE
Update RequestVerifier for additional parameters

### DIFF
--- a/src/Attribute/ConfirmationRoute.php
+++ b/src/Attribute/ConfirmationRoute.php
@@ -11,7 +11,7 @@ class ConfirmationRoute extends Route
     private const METHODS = ['POST'];
 
     /**
-     * @param array|string      $data         data array managed by the Doctrine Annotations library or the path
+     * @param array|string      $data    data array managed by the Doctrine Annotations library or the path
      * @param array|string|null $path
      * @param string[]|string   $schemes
      */

--- a/src/Attribute/RegistrationRoute.php
+++ b/src/Attribute/RegistrationRoute.php
@@ -11,7 +11,7 @@ class RegistrationRoute extends Route
     private const METHODS = ['GET'];
 
     /**
-     * @param array|string      $data         data array managed by the Doctrine Annotations library or the path
+     * @param array|string      $data    data array managed by the Doctrine Annotations library or the path
      * @param array|string|null $path
      * @param string[]|string   $schemes
      */


### PR DESCRIPTION
Latest Shopware version has added parameters that get hashed on Shopware side (invoked [here](https://github.com/shopware/platform/blob/trunk/src/Core/Framework/App/Manifest/ModuleLoader.php#L150) and [here](https://github.com/shopware/platform/blob/trunk/src/Core/Framework/App/Hmac/RequestSigner.php#L47) resulting in request verification failing here.

Long term solution would probably be to either make this payload more dynamic (e.g. imploding all key value pairs apart from the `shopware-shop-signature` one) or defining a fixed set of parameters that get hashed. The former would require some kind of sorting for the query parameters on Shopware side.