### PR TITLE
Add attributes for registration and confirmation route

### DIFF
--- a/src/Attribute/ConfirmationRoute.php
+++ b/src/Attribute/ConfirmationRoute.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\AppBundle\Attribute;
+
+use Attribute;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class ConfirmationRoute extends Route
+{
+    private const METHODS = ['POST'];
+
+    /**
+     * @param array|string      $data         data array managed by the Doctrine Annotations library or the path
+     * @param array|string|null $path
+     * @param string[]|string   $schemes
+     */
+    public function __construct(
+        string $name,
+        $data = [],
+        $path = null,
+        array $requirements = [],
+        array $options = [],
+        array $defaults = [],
+        ?string $host = null,
+        $schemes = [],
+        ?string $condition = null,
+        ?int $priority = null,
+        ?string $locale = null,
+        ?string $format = null,
+        ?bool $utf8 = null,
+        ?bool $stateless = null,
+        ?string $env = null
+    ) {
+        parent::__construct($data, $path, $name, $requirements, $options, $defaults, $host, self::METHODS, $schemes, $condition, $priority, $locale, $format, $utf8, $stateless, $env);
+    }
+}

--- a/src/Attribute/RegistrationRoute.php
+++ b/src/Attribute/RegistrationRoute.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\AppBundle\Attribute;
+
+use Attribute;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class RegistrationRoute extends Route
+{
+    private const METHODS = ['GET'];
+
+    /**
+     * @param array|string      $data         data array managed by the Doctrine Annotations library or the path
+     * @param array|string|null $path
+     * @param string[]|string   $schemes
+     */
+    public function __construct(
+        string $name,
+        $data = [],
+        $path = null,
+        array $requirements = [],
+        array $options = [],
+        array $defaults = [],
+        ?string $host = null,
+        $schemes = [],
+        ?string $condition = null,
+        ?int $priority = null,
+        ?string $locale = null,
+        ?string $format = null,
+        ?bool $utf8 = null,
+        ?bool $stateless = null,
+        ?string $env = null
+    ) {
+        parent::__construct($data, $path, $name, $requirements, $options, $defaults, $host, self::METHODS, $schemes, $condition, $priority, $locale, $format, $utf8, $stateless, $env);
+    }
+}

--- a/src/Client/ShopClient.php
+++ b/src/Client/ShopClient.php
@@ -15,6 +15,8 @@ class ShopClient implements ClientInterface
 {
     private const AUTHENTICATION_ROUTE = '/api/oauth/token';
 
+    private const AUTH_HEADER = 'Authentication';
+
     private ?Credentials $credentials;
 
     public function __construct(
@@ -31,7 +33,7 @@ class ShopClient implements ClientInterface
         }
 
         $response = $this->client->sendRequest($request->withHeader(
-            'Authentication',
+            self::AUTH_HEADER,
             "{$this->credentials->getTokenType()} {$this->credentials->getAccessToken()}"
         ));
 
@@ -43,7 +45,7 @@ class ShopClient implements ClientInterface
         $this->credentials = $this->createToken();
 
         return $this->client->sendRequest($request->withHeader(
-            'Authorization',
+            self::AUTH_HEADER,
             "{$this->credentials->getTokenType()} {$this->credentials->getAccessToken()}"
         ));
     }

--- a/tests/Attribute/ConfirmationRouteTest.php
+++ b/tests/Attribute/ConfirmationRouteTest.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\AppBundle\Test\Attribute;
+
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Shopware\AppBundle\Attribute\ConfirmationRoute;
+
+class ConfirmationRouteTest extends TestCase
+{
+    #[ConfirmationRoute('/confirm', name: 'shopware_app.confirm', methods: ['POST'])]
+    public function testRegistrationRouteAttribute(): void
+    {
+        $reflectionClass = new ReflectionClass($this);
+        $reflectionMethod = $reflectionClass->getMethod('testRegistrationRouteAttribute');
+
+        $reflectionAttribute = $reflectionMethod->getAttributes(ConfirmationRoute::class);
+
+        static::assertEquals($reflectionAttribute[0]->getArguments(), [
+            '0' => '/confirm',
+            'name' => 'shopware_app.confirm',
+            'methods' => [
+                'POST',
+            ],
+        ]);
+    }
+}

--- a/tests/Attribute/RegistrationRouteTest.php
+++ b/tests/Attribute/RegistrationRouteTest.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\AppBundle\Test\Attribute;
+
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Shopware\AppBundle\Attribute\RegistrationRoute;
+
+class RegistrationRouteTest extends TestCase
+{
+    #[RegistrationRoute('/register', name: 'shopware_app.register', methods: ['GET'])]
+    public function testRegistrationRouteAttribute(): void
+    {
+        $reflectionClass = new ReflectionClass($this);
+        $reflectionMethod = $reflectionClass->getMethod('testRegistrationRouteAttribute');
+
+        $reflectionAttribute = $reflectionMethod->getAttributes(RegistrationRoute::class);
+
+        static::assertEquals($reflectionAttribute[0]->getArguments(), [
+            '0' => '/register',
+            'name' => 'shopware_app.register',
+            'methods' => [
+                'GET',
+            ],
+        ]);
+    }
+}

--- a/tests/Client/ShopClientTest.php
+++ b/tests/Client/ShopClientTest.php
@@ -71,7 +71,7 @@ class ShopClientTest extends TestCase
         static::assertEquals('/some-route', $lastRequest->getRequestTarget());
         static::assertEquals([
             'Bearer shopware-access-token',
-        ], $lastRequest->getHeader('Authorization'));
+        ], $lastRequest->getHeader('Authentication'));
     }
 
     public function testItRefreshesTheTokenIfTheClientReturnsAn401(): void

--- a/tests/Registration/RegistrationServiceTest.php
+++ b/tests/Registration/RegistrationServiceTest.php
@@ -45,7 +45,7 @@ class RegistrationServiceTest extends KernelTestCase
     {
         $shopId = 'unique-id';
         $shopUrl = 'shop.test';
-        $shopSecret = 'i-am-secret';
+        $shopSecret = $this->getContainer()->getParameter('shopware_app.setup.secret');
 
         $query = Query::build([
             'shop-id' => $shopId,
@@ -53,7 +53,7 @@ class RegistrationServiceTest extends KernelTestCase
             'timestamp' => 'now',
         ]);
 
-        $signature = hash_hmac('sha256', $query, $this->getContainer()->getParameter('shopware_app.setup.secret'));
+        $signature = hash_hmac('sha256', $query, $shopSecret);
 
         $registrationRequest = new Request(
             'GET',
@@ -88,7 +88,7 @@ class RegistrationServiceTest extends KernelTestCase
         static::assertEquals([
             'proof' => $expectedProof,
             'confirmation_url' => '/confirm',
-            'secret' => 'i-am-secret',
+            'secret' => $shopSecret,
         ], $registration);
     }
 


### PR DESCRIPTION
We accidentially added the attributes for confirmation and registration routes to the AppTemplate project. But since we need them to create the manifest.xml we have to add them in the bundle