### PR TITLE
Provide a ShopInterface instance as service

### DIFF
--- a/src/DependencyInjection/ShopProvider.php
+++ b/src/DependencyInjection/ShopProvider.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\AppBundle\DependencyInjection;
+
+use Psr\Http\Message\RequestInterface;
+use Shopware\App\SDK\Shop\ShopInterface;
+use Shopware\App\SDK\Shop\ShopResolver;
+use Shopware\AppBundle\AppRequest;
+use Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class ShopProvider
+{
+    public function __construct(
+        private readonly RequestStack $requestStack,
+        private readonly ShopResolver $shopResolver,
+        private readonly HttpMessageFactoryInterface $httpFoundationFactory
+    ) {
+    }
+
+    public function provide(): ?ShopInterface
+    {
+        $currentRequest = $this->requestStack->getCurrentRequest();
+
+        if (!$currentRequest instanceof Request) {
+            return null;
+        }
+
+        $psrRequest = $currentRequest->attributes->get(AppRequest::PSR_REQUEST_ATTRIBUTE);
+
+        if (!$psrRequest instanceof RequestInterface) {
+            $psrRequest = $this->httpFoundationFactory->createRequest($currentRequest);
+            $currentRequest->attributes->set(AppRequest::PSR_REQUEST_ATTRIBUTE, $psrRequest);
+        }
+
+        $shop = $currentRequest->attributes->get(AppRequest::SHOP_ATTRIBUTE);
+
+        if (!$shop instanceof ShopInterface) {
+            $shop = $this->shopResolver->resolveShop($psrRequest);
+            $currentRequest->attributes->set(AppRequest::SHOP_ATTRIBUTE, $shop);
+        }
+
+        return $shop;
+    }
+}

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -12,7 +12,7 @@
             <argument/>
             <argument type="service" id="Symfony\Component\Routing\Generator\UrlGeneratorInterface"/>
         </service>
-               
+
         <service id="Shopware\App\SDK\HttpClient\ClientFactory"/>
 
         <service id="Shopware\App\SDK\AppConfiguration">
@@ -65,6 +65,11 @@
 
         <service id="Shopware\AppBundle\ArgumentValueResolver\ContextArgumentResolver"/>
         <service id="Shopware\AppBundle\EventListener\ResponseSignerListener"/>
+
+        <service id="Shopware\AppBundle\DependencyInjection\ShopProvider" />
+        <service id="Shopware\App\SDK\Shop\ShopInterface">
+            <factory service="Shopware\AppBundle\DependencyInjection\ShopProvider" method="provide" />
+        </service>
 
         <!-- PSR Integration -->
         <service id="Symfony\Bridge\PsrHttpMessage\HttpFoundationFactoryInterface" class="Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory"/>

--- a/tests/DependencyInjection/ShopProviderTest.php
+++ b/tests/DependencyInjection/ShopProviderTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\AppBundle\Test\DependencyInjection;
+
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Shopware\App\SDK\Shop\ShopInterface;
+use Shopware\App\SDK\Shop\ShopResolver;
+use Shopware\AppBundle\DependencyInjection\ShopProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class ShopProviderTest extends TestCase
+{
+    public function testProvideShop(): void
+    {
+        $requestStack = $this->getRequestStack();
+
+        $shopResolver = static::createMock(ShopResolver::class);
+        $shopResolver->method('resolveShop')->willReturn(static::createMock(ShopInterface::class));
+        $shopProvider = new ShopProvider(
+            $requestStack,
+            $shopResolver,
+            $this->getPsrHttpFactory()
+        );
+
+        $result = $shopProvider->provide();
+
+        static::assertInstanceOf(ShopInterface::class, $result);
+    }
+
+    public function testDoesNotProvideShopWhenNoRequest(): void
+    {
+        // create empty request stack and don't push a request in
+        $requestStack = new RequestStack();
+
+        $shopResolver = static::createMock(ShopResolver::class);
+        $shopResolver->method('resolveShop')->willReturn(static::createMock(ShopInterface::class));
+        $shopProvider = new ShopProvider(
+            $requestStack,
+            $shopResolver,
+            $this->getPsrHttpFactory()
+        );
+
+        $result = $shopProvider->provide();
+
+        static::assertNull($result);
+    }
+
+    public function getRequestStack(): RequestStack
+    {
+        $request = new Request();
+        $request->headers->set('HOST', 'localhost');
+        $request->attributes->set('shopware-app-context', 'test');
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        return $requestStack;
+    }
+
+    public function getPsrHttpFactory(): PsrHttpFactory
+    {
+        return new PsrHttpFactory(new Psr17Factory(), new Psr17Factory(), new Psr17Factory(), new Psr17Factory());
+    }
+}

--- a/tests/DependencyInjection/ShopProviderTest.php
+++ b/tests/DependencyInjection/ShopProviderTest.php
@@ -5,13 +5,22 @@ declare(strict_types=1);
 namespace Shopware\AppBundle\Test\DependencyInjection;
 
 use Nyholm\Psr7\Factory\Psr17Factory;
+use Psr\Http\Message\RequestInterface;
+use Shopware\App\SDK\Authentication\RequestVerifier;
+use Shopware\App\SDK\Context\ContextResolver;
 use Shopware\App\SDK\Shop\ShopInterface;
 use Shopware\App\SDK\Shop\ShopResolver;
+use Shopware\App\SDK\Test\MockShop;
+use Shopware\App\SDK\Test\MockShopRepository;
+use Shopware\AppBundle\AppRequest;
+use Shopware\AppBundle\ArgumentValueResolver\ContextArgumentResolver;
 use Shopware\AppBundle\DependencyInjection\ShopProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
+use Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 
 class ShopProviderTest extends TestCase
 {
@@ -29,6 +38,10 @@ class ShopProviderTest extends TestCase
 
         $result = $shopProvider->provide();
 
+        $currentRequest = $requestStack->getCurrentRequest();
+
+        static::assertInstanceOf(ShopInterface::class, $currentRequest->attributes->get(AppRequest::SHOP_ATTRIBUTE));
+        static::assertInstanceOf(RequestInterface::class, $currentRequest->attributes->get(AppRequest::PSR_REQUEST_ATTRIBUTE));
         static::assertInstanceOf(ShopInterface::class, $result);
     }
 
@@ -48,6 +61,68 @@ class ShopProviderTest extends TestCase
         $result = $shopProvider->provide();
 
         static::assertNull($result);
+    }
+
+    public function testExistingShopIsNotResolved(): void
+    {
+        $shopResolver = static::createMock(ShopResolver::class);
+        $shopResolver
+            ->expects(static::never())
+            ->method('resolveShop');
+
+        $requestStack = new RequestStack();
+
+        $shop = new MockShop('123', 'https://example.com', 'secret');
+
+        $request = new Request(attributes: [AppRequest::SHOP_ATTRIBUTE => $shop]);
+        $request->headers->set('HOST', 'localhost');
+        $request->attributes->set('shopware-app-context', 'test');
+
+        $requestStack->push($request);
+
+        $shopProvider = new ShopProvider(
+            $requestStack,
+            $shopResolver,
+            $this->getPsrHttpFactory()
+        );
+
+        $result = $shopProvider->provide();
+
+        static::assertInstanceOf(ShopInterface::class, $result);
+    }
+
+    public function testExistingPsrRequestIsNotConverted(): void
+    {
+        $repository = new MockShopRepository();
+        $shopResolver = new ShopResolver($repository, static::createMock(RequestVerifier::class));
+
+        $shop = new MockShop('123', 'https://example.com', 'secret');
+
+        $repository->createShop($shop);
+
+        $psrRequest = new \Nyholm\Psr7\Request(
+            'POST',
+            'https://localhost',
+            ['Content-Type' => 'application/json'],
+            \json_encode(['source' => ['shopId' => '123']])
+        );
+
+        $request = new Request(attributes: [AppRequest::PSR_REQUEST_ATTRIBUTE => $psrRequest]);
+        $request->headers->set('HOST', 'localhost');
+        $request->attributes->set('shopware-app-context', 'test');
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $shopProvider = new ShopProvider(
+            $requestStack,
+            $shopResolver,
+            $this->getPsrHttpFactory()
+        );
+
+        $result = $shopProvider->provide();
+
+        static::assertSame($shop, $result);
     }
 
     public function getRequestStack(): RequestStack

--- a/tests/DependencyInjection/ShopProviderTest.php
+++ b/tests/DependencyInjection/ShopProviderTest.php
@@ -7,20 +7,16 @@ namespace Shopware\AppBundle\Test\DependencyInjection;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Http\Message\RequestInterface;
 use Shopware\App\SDK\Authentication\RequestVerifier;
-use Shopware\App\SDK\Context\ContextResolver;
 use Shopware\App\SDK\Shop\ShopInterface;
 use Shopware\App\SDK\Shop\ShopResolver;
 use Shopware\App\SDK\Test\MockShop;
 use Shopware\App\SDK\Test\MockShopRepository;
 use Shopware\AppBundle\AppRequest;
-use Shopware\AppBundle\ArgumentValueResolver\ContextArgumentResolver;
 use Shopware\AppBundle\DependencyInjection\ShopProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
-use Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 
 class ShopProviderTest extends TestCase
 {


### PR DESCRIPTION
During the development of our app, an instance of shop is required throughout the application.

Just always giving it around as parameter to class construction or method execution only adds more bloat and the senseless overuse of a factory pattern.

Thus, I found a way to provide the `ShopInterface` instance as a service to the whole application.