### PR TITLE
fix: use shop interface instead of abstract shop class

### DIFF
--- a/infection.json5
+++ b/infection.json5
@@ -12,5 +12,10 @@
     },
     "mutators": {
         "@default": true,
+        "MatchArmRemoval": {
+            "ignoreSourceCodeByRegex": [
+                "default => throw new \\\\RuntimeException\\(sprintf\\('Unsupported type %s', \\$type\\)\\).*"
+            ]
+        }
     }
 }

--- a/src/Entity/ShopRepositoryBridge.php
+++ b/src/Entity/ShopRepositoryBridge.php
@@ -11,19 +11,19 @@ use Shopware\App\SDK\Shop\ShopInterface;
 use Shopware\App\SDK\Shop\ShopRepositoryInterface;
 
 /**
- * @implements ShopRepositoryInterface<AbstractShop>
+ * @implements ShopRepositoryInterface<ShopInterface>
  */
 class ShopRepositoryBridge implements ShopRepositoryInterface
 {
     /**
-     * @param class-string<AbstractShop> $entityClass
+     * @param class-string<ShopInterface> $entityClass
      */
     public function __construct(
         private readonly string $entityClass,
         private readonly ManagerRegistry $registry
     ) {
-        if (!is_subclass_of($this->entityClass, AbstractShop::class)) {
-            throw new \InvalidArgumentException(sprintf('The shop entity class "%s" must extend "%s"', $this->entityClass, AbstractShop::class));
+        if (!is_subclass_of($this->entityClass, ShopInterface::class)) {
+            throw new \InvalidArgumentException(sprintf('The shop entity class "%s" must implement "%s"', $this->entityClass, ShopInterface::class));
         }
         if ($this->registry->getManagerForClass($this->entityClass) === null) {
             throw new \InvalidArgumentException(sprintf('The shop entity class "%s" must be a doctrine managed entity', $this->entityClass));
@@ -65,9 +65,8 @@ class ShopRepositoryBridge implements ShopRepositoryInterface
 
     private function getManager(): ObjectManager
     {
+        /** @var ObjectManager $manager */
         $manager = $this->registry->getManagerForClass($this->entityClass);
-        // we check that $shopEntity is a doctrine entity in the constructor
-        assert($manager !== null);
         return $manager;
     }
 }

--- a/tests/Entity/BaseShopRepositoryBridgeTest.php
+++ b/tests/Entity/BaseShopRepositoryBridgeTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 
 class BaseShopRepositoryBridgeTest extends TestCase
 {
-    public function testConstructionFailsWithIncorrectShopEntity()
+    public function testConstructionFailsWithIncorrectShopEntity(): void
     {
         static::expectException(\InvalidArgumentException::class);
 
@@ -34,7 +34,7 @@ class BaseShopRepositoryBridgeTest extends TestCase
     }
 
 
-    public function testConstructionFailsForNonDoctrineEntities()
+    public function testConstructionFailsForNonDoctrineEntities(): void
     {
         $this->expectException(\InvalidArgumentException::class);
 
@@ -51,7 +51,7 @@ class BaseShopRepositoryBridgeTest extends TestCase
         );
     }
 
-    public function testBridgeCanConstructCustomShopEntity()
+    public function testBridgeCanConstructCustomShopEntity(): void
     {
         $customShop = new class ('', '', '') extends AbstractShop {
             public function __construct(string $shopId, string $shopUrl, string $shopSecret)


### PR DESCRIPTION
Checking for AbstractShop in the Repository leaves devs no choice, but to use the abstract class.

Changed this to check for the ShopInterface instead