### PR TITLE
fix: check if api is reachable during registration

### DIFF
--- a/src/EventListener/BeforeRegistrationStartsListener.php
+++ b/src/EventListener/BeforeRegistrationStartsListener.php
@@ -33,7 +33,7 @@ class BeforeRegistrationStartsListener
         $shop = $event->getShop();
 
         try {
-            $this->httpClient->request('HEAD', $shop->getShopUrl(), [
+            $this->httpClient->request('HEAD', sprintf("%s/api/_info/config", $shop->getShopUrl()), [
                 'timeout' => 10,
                 'max_redirects' => 0,
             ]);

--- a/tests/EventListener/BeforeRegistrationStartsListenerTest.php
+++ b/tests/EventListener/BeforeRegistrationStartsListenerTest.php
@@ -59,7 +59,7 @@ final class BeforeRegistrationStartsListenerTest extends TestCase
         $this->httpClient
             ->expects(self::once())
             ->method('request')
-            ->with('HEAD', 'https://shop-url.com', [
+            ->with('HEAD', 'https://shop-url.com/api/_info/config', [
                 'timeout' => 10,
                 'max_redirects' => 0,
             ]);
@@ -91,7 +91,7 @@ final class BeforeRegistrationStartsListenerTest extends TestCase
         $this->httpClient
             ->expects(self::once())
             ->method('request')
-            ->with('HEAD', 'https://shop-url.com', [
+            ->with('HEAD', 'https://shop-url.com/api/_info/config', [
                 'timeout' => 10,
                 'max_redirects' => 0,
             ])


### PR DESCRIPTION
Fixes https://github.com/shopware/app-bundle-symfony/issues/55
During registration, we check if the API is reachable instead of just the `APP_URL` because this could also be mapped to a sales channel which is currently in maintenance mode. 