### PR TITLE
fix: trim trailing slashes in shop url in before registration start l…

### DIFF
--- a/src/EventListener/BeforeRegistrationStartsListener.php
+++ b/src/EventListener/BeforeRegistrationStartsListener.php
@@ -33,7 +33,8 @@ class BeforeRegistrationStartsListener
         $shop = $event->getShop();
 
         try {
-            $this->httpClient->request('HEAD', sprintf("%s/api/_info/config", $shop->getShopUrl()), [
+            $shopUrl = rtrim($shop->getShopUrl(), '/');
+            $this->httpClient->request('HEAD', sprintf("%s/api/_info/config", $shopUrl), [
                 'timeout' => 10,
                 'max_redirects' => 0,
             ]);

--- a/tests/EventListener/BeforeRegistrationStartsListenerTest.php
+++ b/tests/EventListener/BeforeRegistrationStartsListenerTest.php
@@ -54,7 +54,7 @@ final class BeforeRegistrationStartsListenerTest extends TestCase
         $shop
             ->expects(self::once())
             ->method('getShopUrl')
-            ->willReturn('https://shop-url.com');
+            ->willReturn('https://shop-url.com/');
 
         $this->httpClient
             ->expects(self::once())
@@ -80,13 +80,13 @@ final class BeforeRegistrationStartsListenerTest extends TestCase
     public function testListenerMustThrowExceptionBecauseTheShopURLIsNotReachable(): void
     {
         $this->expectException(ShopURLIsNotReachableException::class);
-        $this->expectExceptionMessage('Shop URL "https://shop-url.com" is not reachable from the application server.');
+        $this->expectExceptionMessage('Shop URL "https://shop-url.com/" is not reachable from the application server.');
 
         $shop = $this->createMock(ShopInterface::class);
         $shop
             ->expects(self::exactly(2))
             ->method('getShopUrl')
-            ->willReturn('https://shop-url.com');
+            ->willReturn('https://shop-url.com/');
 
         $this->httpClient
             ->expects(self::once())


### PR DESCRIPTION
If there is a trailing slash in the app url during registration, we need to trim it in order to check if the shop is reachable. This has already been fixed in the app php sdk so that can't happen anymore after the registration is done. As this could still happen during registration and the event which we get contains the whole request, we need to trim it at this point. Trimming it before this would result in an inconsistency between the URL in `$event->getRequest()` and `$event->getShop()->getShopUrl()`. 