### PR TITLE
fix: shop is not reachable when getting 401 unauthorized response

### DIFF
--- a/src/EventListener/BeforeRegistrationStartsListener.php
+++ b/src/EventListener/BeforeRegistrationStartsListener.php
@@ -7,6 +7,7 @@ namespace Shopware\AppBundle\EventListener;
 use Shopware\App\SDK\Event\BeforeRegistrationStartsEvent;
 use Shopware\AppBundle\Exception\ShopURLIsNotReachableException;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 #[AsEventListener]
@@ -38,6 +39,10 @@ class BeforeRegistrationStartsListener
                 'max_redirects' => 0,
             ]);
         } catch (\Throwable $e) {
+            if (!$e instanceof TransportExceptionInterface) {
+                return;
+            }
+
             throw new ShopURLIsNotReachableException($shop->getShopUrl(), $e);
         }
     }


### PR DESCRIPTION
This PR started with this discussion: https://github.com/shopware/app-bundle-symfony/pull/56#discussion_r1920271350
I tested it with multiple shops and can confirm that without these changes, some of them would not be able to pass this check as they might return 401 instead of 200. With this change, I was not able to find a shop where 401 would not pass this check. 